### PR TITLE
[ODPR-1754] - Fix Warnings in the code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val microservice = Project("digital-platform-reporting", file("."))
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     // https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html
     // suppress warnings in generated routes files
-    scalacOptions += "-Wconf:src=routes/.*:s,src=src_managed/.*:s",
+    scalacOptions += "-Wconf:src=routes/.*:s,src=src_managed/.*:s,msg=Flag.*repeatedly:s",
     scalaxbGenerateDispatchClient := false
   )
   .settings(resolvers += Resolver.jcenterRepo)


### PR DESCRIPTION
Supress the following sbt warnings:
[warn] Flag -deprecation set repeatedly
[warn] Flag -unchecked set repeatedly
[warn] Flag -encoding set repeatedly
using compilerOptions: "-Wconf:msg=Flag.*repeatedly:s"