### PR TITLE
DLS-13216 | Make upload-success callback idempotent

### DIFF
--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -29,7 +29,7 @@ import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import services.UuidService
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, RequestId, StringContextOps}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import utils.DateTimeFormats.RFC7231Formatter
 
 import java.time.Clock

--- a/app/controllers/SubmissionController.scala
+++ b/app/controllers/SubmissionController.scala
@@ -123,13 +123,14 @@ class SubmissionController @Inject() (
     Action.async(parse.json[UploadSuccessRequest]) { implicit request =>
       submissionRepository.get(request.body.dprsId, id).flatMap {
         case Some(submission)
-          if submission.state.isInstanceOf[Ready.type] ||
-            submission.state.isInstanceOf[Uploading.type] ||
-            submission.state.isInstanceOf[UploadFailed] =>
+          if uploadSuccessService.canProcessUploadSuccess(submission.state) =>
 
           uploadSuccessService.enqueueUploadSuccess(id, request.body).map { _ =>
             Ok
           }
+
+        case Some(submission) if uploadSuccessService.hasAlreadyHandledUploadSuccess(submission.state, request.body) =>
+          Future.successful(Ok)
 
         case Some(_) =>
           Future.successful(Conflict)

--- a/app/services/UploadSuccessService.scala
+++ b/app/services/UploadSuccessService.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.mongo.workitem.{ProcessingStatus, WorkItem}
 import repository.{SubmissionRepository, UploadSuccessWorkItemRepository}
 import models.audit.FileUploadedEvent
 import models.audit.FileUploadedEvent.FileUploadOutcome
-import models.submission.Submission.State.{Ready, UploadFailed, Uploading, Validated}
+import models.submission.Submission.State.{Approved, Ready, Rejected, Submitted, UploadFailed, Uploading, Validated}
 import models.submission.{Submission, UploadSuccessRequest, UploadSuccessWorkItem}
 import org.apache.pekko.Done
 
@@ -85,11 +85,35 @@ class UploadSuccessService @Inject()(
       case false => Future.successful(Done)
     }
 
-  private def isProcessable(state: Submission.State): Boolean =
-      state.isInstanceOf[Ready.type] || state.isInstanceOf[Uploading.type] || state.isInstanceOf[UploadFailed]
+  def canProcessUploadSuccess(state: Submission.State): Boolean =
+    state.isInstanceOf[Ready.type] || state.isInstanceOf[Uploading.type] || state.isInstanceOf[UploadFailed]
+
+  def hasAlreadyHandledUploadSuccess(state: Submission.State, request: UploadSuccessRequest): Boolean =
+    state match {
+      case Validated(downloadUrl, _, fileName, checksum, size) =>
+        downloadUrl == request.downloadUrl &&
+          fileName == request.fileName &&
+          checksum == request.checksum &&
+          size == request.size
+      case Submitted(fileName, _, size) =>
+        fileName == request.fileName && size == request.size
+      case Approved(fileName, _) =>
+        fileName == request.fileName
+      case Rejected(fileName, _) =>
+        fileName == request.fileName
+      case _ =>
+        false
+    }
 
   private def processWorkItem(workItem: WorkItem[UploadSuccessWorkItem]): Future[Unit] = {
     val item = workItem.item
+    val callback = UploadSuccessRequest(
+      dprsId = item.dprsId,
+      downloadUrl = item.downloadUrl,
+      fileName = item.fileName,
+      checksum = item.checksum,
+      size = item.size
+    )
     
     given HeaderCarrier = HeaderCarrier(
       requestId = item.requestId.map(RequestId.apply)
@@ -99,7 +123,10 @@ class UploadSuccessService @Inject()(
       case None =>
         Future.failed(new RuntimeException(s"Submission not found for dprsId=${item.dprsId}, submissionId=${item.submissionId}"))
 
-      case Some(submission) if !isProcessable(submission.state) =>
+      case Some(submission) if hasAlreadyHandledUploadSuccess(submission.state, callback) =>
+        Future.successful(())
+
+      case Some(submission) if !canProcessUploadSuccess(submission.state) =>
         Future.failed(new RuntimeException(
           s"Submission ${item.submissionId} is in unexpected state ${submission.state}"
       ))

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-work-item-repo-play-30"  % hmrcMongoVersion,
     "com.beachape"            %% "enumeratum-play"                    % "1.9.1",
     "org.typelevel"           %% "cats-core"                          % "2.13.0",
-    "uk.gov.hmrc"             %% "internal-auth-client-play-30"       % "4.3.0",
+    "uk.gov.hmrc"             %% "internal-auth-client-play-30"       % "4.4.0",
     "javax.xml.bind"          %  "jaxb-api"                           % "2.3.1",
     "org.apache.pekko"        %% "pekko-connectors-xml"               % "1.0.0"
   )

--- a/test/controllers/SubmissionControllerSpec.scala
+++ b/test/controllers/SubmissionControllerSpec.scala
@@ -89,7 +89,7 @@ class SubmissionControllerSpec
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    Mockito.reset(mockSubmissionRepository, mockAuthConnector, mockValidationService, mockSubmissionService, mockViewSubmissionsService, mockAuditService)
+    Mockito.reset(mockSubmissionRepository, mockAuthConnector, mockValidationService, mockSubmissionService, mockViewSubmissionsService, mockUploadSuccessService, mockAuditService)
   }
 
   private val readyGen: Gen[Ready.type] = Gen.const(Ready)
@@ -444,8 +444,9 @@ class SubmissionControllerSpec
 
           "must return OK" in {
 
+            val callback = UploadSuccessRequest(dprsId, downloadUrl, fileName, checksum, size)
             val request = FakeRequest(routes.SubmissionController.uploadSuccess(uuid))
-              .withBody(Json.toJson(UploadSuccessRequest(dprsId, downloadUrl, fileName, checksum, size)))
+              .withBody(Json.toJson(callback))
 
             val state = Gen.oneOf(readyGen, uploadingGen, uploadFailedGen).sample.value
             val existingSubmission = Submission(
@@ -461,7 +462,8 @@ class SubmissionControllerSpec
             )
 
             when(mockSubmissionRepository.get(any(), any())).thenReturn(Future.successful(Some(existingSubmission)))
-            when(mockUploadSuccessService.enqueueUploadSuccess(any(), any())(using any()))
+            when(mockUploadSuccessService.canProcessUploadSuccess(state)).thenReturn(true)
+            when(mockUploadSuccessService.enqueueUploadSuccess(eqTo(uuid), eqTo(callback))(using any()))
               .thenReturn(Future.successful(Done))
 
             val result = route(app, request).value
@@ -470,19 +472,22 @@ class SubmissionControllerSpec
             contentAsString(result).trim mustEqual ""
 
             verify(mockSubmissionRepository).get(dprsId, uuid)
+            verify(mockUploadSuccessService).canProcessUploadSuccess(state)
+            verify(mockUploadSuccessService).enqueueUploadSuccess(eqTo(uuid), eqTo(callback))(using any())
             verify(mockSubmissionRepository, never()).save(any())
             verify(mockAuditService, never()).audit(any())(using any(), any())
           }
       }
 
-      "when the matching submission is in any other state" - {
+      "when the callback has already been handled" - {
 
-        "must return CONFLICT" in {
+        "must return OK without enqueueing another work item" in {
 
+          val callback = UploadSuccessRequest(dprsId, downloadUrl, fileName, checksum, size)
           val request = FakeRequest(routes.SubmissionController.uploadSuccess(uuid))
-            .withBody(Json.toJson(UploadSuccessRequest(dprsId, downloadUrl, fileName, checksum, size)))
+            .withBody(Json.toJson(callback))
 
-          val state = Gen.oneOf(validatedGen, submittedGen, approvedGen, rejectedGen).sample.value
+          val state = Validated(downloadUrl, Year.of(2024), fileName, checksum, size)
           val existingSubmission = Submission(
             _id = uuid,
             submissionType = SubmissionType.Xml,
@@ -496,14 +501,52 @@ class SubmissionControllerSpec
           )
 
           when(mockSubmissionRepository.get(any(), any())).thenReturn(Future.successful(Some(existingSubmission)))
-          when(mockSubmissionRepository.save(any())).thenReturn(Future.successful(Done))
+          when(mockUploadSuccessService.hasAlreadyHandledUploadSuccess(eqTo(state), eqTo(callback))).thenReturn(true)
+
+          val result = route(app, request).value
+
+          status(result) mustEqual OK
+          contentAsString(result).trim mustEqual ""
+
+          verify(mockSubmissionRepository).get(dprsId, uuid)
+          verify(mockUploadSuccessService).hasAlreadyHandledUploadSuccess(eqTo(state), eqTo(callback))
+          verify(mockUploadSuccessService, never()).enqueueUploadSuccess(any(), any())(using any())
+          verify(mockSubmissionRepository, never()).save(any())
+        }
+      }
+
+      "when the callback is for a different upload after processing has finished" - {
+
+        "must return CONFLICT" in {
+
+          val callback = UploadSuccessRequest(dprsId, downloadUrl, fileName, checksum, size)
+          val request = FakeRequest(routes.SubmissionController.uploadSuccess(uuid))
+            .withBody(Json.toJson(callback))
+
+          val state = Validated(downloadUrl, Year.of(2024), fileName, "other-checksum", size)
+          val existingSubmission = Submission(
+            _id = uuid,
+            submissionType = SubmissionType.Xml,
+            dprsId = dprsId,
+            operatorId = operatorId,
+            operatorName = operatorName,
+            assumingOperatorName = None,
+            state = state,
+            created = now,
+            updated = now
+          )
+
+          when(mockSubmissionRepository.get(any(), any())).thenReturn(Future.successful(Some(existingSubmission)))
+          when(mockUploadSuccessService.hasAlreadyHandledUploadSuccess(eqTo(state), eqTo(callback))).thenReturn(false)
 
           val result = route(app, request).value
 
           status(result) mustEqual CONFLICT
 
           verify(mockSubmissionRepository).get(dprsId, uuid)
-          verify(mockSubmissionRepository, times(0)).save(any())
+          verify(mockUploadSuccessService).hasAlreadyHandledUploadSuccess(eqTo(state), eqTo(callback))
+          verify(mockUploadSuccessService, never()).enqueueUploadSuccess(any(), any())(using any())
+          verify(mockSubmissionRepository, never()).save(any())
         }
       }
     }

--- a/test/services/UploadSuccessServiceSpec.scala
+++ b/test/services/UploadSuccessServiceSpec.scala
@@ -33,7 +33,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import uk.gov.hmrc.mongo.workitem.{ProcessingStatus, WorkItem}
 import models.submission.*
-import models.submission.Submission.State.{UploadFailed, Uploading, Validated}
+import models.submission.Submission.State.{Approved, Ready, Rejected, Submitted, UploadFailed, Uploading, Validated}
 import models.submission.Submission.UploadFailureReason.SchemaValidationError
 import org.bson.types.ObjectId
 import org.scalatest.BeforeAndAfterEach
@@ -178,6 +178,88 @@ class UploadSuccessServiceSpec
     }
   }
 
+  "UploadSuccessService.canProcessUploadSuccess" should {
+
+    "allow callbacks before validation has finished" in {
+      val statesBeforeValidation = Seq[Submission.State](
+        Ready,
+        Uploading,
+        UploadFailed(SchemaValidationError(Seq.empty, false), None)
+      )
+
+      statesBeforeValidation.foreach { state =>
+        uploadSuccessService.canProcessUploadSuccess(state) mustBe true
+      }
+    }
+
+    "stop callbacks from being processed again once the submission has moved on" in {
+      val statesAfterUpload = Seq[Submission.State](
+        Validated(request.downloadUrl, Year.of(2025), request.fileName, request.checksum, request.size),
+        Submitted(request.fileName, Year.of(2025), request.size),
+        Approved(request.fileName, Year.of(2025)),
+        Rejected(request.fileName, Year.of(2025))
+      )
+
+      statesAfterUpload.foreach { state =>
+        uploadSuccessService.canProcessUploadSuccess(state) mustBe false
+      }
+    }
+  }
+
+  "UploadSuccessService.hasAlreadyHandledUploadSuccess" should {
+
+    "recognise retries after upload processing has finished" in {
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(
+        Validated(request.downloadUrl, Year.of(2025), request.fileName, request.checksum, request.size),
+        request
+      ) mustBe true
+
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(
+        Submitted(request.fileName, Year.of(2025), request.size),
+        request
+      ) mustBe true
+
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(
+        Approved(request.fileName, Year.of(2025)),
+        request
+      ) mustBe true
+
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(
+        Rejected(request.fileName, Year.of(2025)),
+        request
+      ) mustBe true
+    }
+
+    "reject callbacks that do not match the upload already on the submission" in {
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(Ready, request) mustBe false
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(Uploading, request) mustBe false
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(
+        UploadFailed(SchemaValidationError(Seq.empty, false), Some(request.fileName)),
+        request
+      ) mustBe false
+
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(
+        Validated(request.downloadUrl, Year.of(2025), request.fileName, "other-checksum", request.size),
+        request
+      ) mustBe false
+
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(
+        Submitted(request.fileName, Year.of(2025), request.size + 1),
+        request
+      ) mustBe false
+
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(
+        Approved("other-file.xml", Year.of(2025)),
+        request
+      ) mustBe false
+
+      uploadSuccessService.hasAlreadyHandledUploadSuccess(
+        Rejected("other-file.xml", Year.of(2025)),
+        request
+      ) mustBe false
+    }
+  }
+
   "processNextUploadSuccess" should {
 
     "return false when no outstanding work item exists" in {
@@ -252,6 +334,104 @@ class UploadSuccessServiceSpec
       verify(workItemRepository).complete(eqTo(workItem.id), eqTo(ProcessingStatus.Succeeded))
       verify(workItemRepository, never()).markAs(any[ObjectId], any[ProcessingStatus], any[Option[Instant]])
       verify(auditService).audit(
+        any[FileUploadedEvent]
+      )(using any[OWrites[FileUploadedEvent]], any[HeaderCarrier])
+    }
+
+    "not validate a duplicate callback once the file has already been validated" in {
+      val workItem = workItemOf(queuedItem)
+      val submissionAlreadyValidated = baseSubmission.copy(
+        state = Validated(
+          downloadUrl = queuedItem.downloadUrl,
+          reportingPeriod = Year.of(2025),
+          fileName = queuedItem.fileName,
+          checksum = queuedItem.checksum,
+          size = queuedItem.size
+        )
+      )
+
+      when(workItemRepository.pullOutstanding(any[Instant], any[Instant]))
+        .thenReturn(Future.successful(Some(workItem)))
+      when(submissionRepository.get("DPRS123", "submission-1"))
+        .thenReturn(Future.successful(Some(submissionAlreadyValidated)))
+      when(workItemRepository.complete(eqTo(workItem.id), eqTo(ProcessingStatus.Succeeded)))
+        .thenReturn(Future.successful(true))
+
+      uploadSuccessService.processNextUploadSuccess().futureValue mustBe true
+
+      verify(validationService, never()).validateXml(any[String], any[String], any(), any[String])
+      verify(submissionRepository, never()).save(any[Submission])
+      verify(workItemRepository).complete(eqTo(workItem.id), eqTo(ProcessingStatus.Succeeded))
+      verify(workItemRepository, never()).markAs(any[ObjectId], any[ProcessingStatus], any[Option[Instant]])
+      verify(auditService, never()).audit(
+        any[FileUploadedEvent]
+      )(using any[OWrites[FileUploadedEvent]], any[HeaderCarrier])
+    }
+
+    "not validate a duplicate callback once the file has already been submitted" in {
+      val workItem = workItemOf(queuedItem)
+      val submissionAlreadySubmitted = baseSubmission.copy(
+        state = Submitted(
+          fileName = queuedItem.fileName,
+          reportingPeriod = Year.of(2025),
+          size = queuedItem.size
+        )
+      )
+
+      when(workItemRepository.pullOutstanding(any[Instant], any[Instant]))
+        .thenReturn(Future.successful(Some(workItem)))
+      when(submissionRepository.get("DPRS123", "submission-1"))
+        .thenReturn(Future.successful(Some(submissionAlreadySubmitted)))
+      when(workItemRepository.complete(eqTo(workItem.id), eqTo(ProcessingStatus.Succeeded)))
+        .thenReturn(Future.successful(true))
+
+      uploadSuccessService.processNextUploadSuccess().futureValue mustBe true
+
+      verify(validationService, never()).validateXml(any[String], any[String], any(), any[String])
+      verify(submissionRepository, never()).save(any[Submission])
+      verify(workItemRepository).complete(eqTo(workItem.id), eqTo(ProcessingStatus.Succeeded))
+      verify(workItemRepository, never()).markAs(any[ObjectId], any[ProcessingStatus], any[Option[Instant]])
+      verify(auditService, never()).audit(
+        any[FileUploadedEvent]
+      )(using any[OWrites[FileUploadedEvent]], any[HeaderCarrier])
+    }
+
+    "fail the work item when the validated submission belongs to another upload" in {
+      val workItem = workItemOf(queuedItem)
+      val submissionWithDifferentUpload = baseSubmission.copy(
+        state = Validated(
+          downloadUrl = queuedItem.downloadUrl,
+          reportingPeriod = Year.of(2025),
+          fileName = queuedItem.fileName,
+          checksum = "other-checksum",
+          size = queuedItem.size
+        )
+      )
+
+      when(workItemRepository.pullOutstanding(any[Instant], any[Instant]))
+        .thenReturn(Future.successful(Some(workItem)))
+      when(submissionRepository.get("DPRS123", "submission-1"))
+        .thenReturn(Future.successful(Some(submissionWithDifferentUpload)))
+      when(
+        workItemRepository.markAs(
+          eqTo(workItem.id),
+          eqTo(ProcessingStatus.Failed),
+          any[Option[Instant]]
+        )
+      ).thenReturn(Future.successful(true))
+
+      val result = uploadSuccessService.processNextUploadSuccess().failed.futureValue
+      result.getMessage must include("unexpected state")
+
+      verify(validationService, never()).validateXml(any[String], any[String], any(), any[String])
+      verify(submissionRepository, never()).save(any[Submission])
+      verify(workItemRepository).markAs(
+        eqTo(workItem.id),
+        eqTo(ProcessingStatus.Failed),
+        any[Option[Instant]]
+      )
+      verify(workItemRepository, never()).complete(any[ObjectId], any[ResultStatus])
+      verify(auditService, never()).audit(
         any[FileUploadedEvent]
       )(using any[OWrites[FileUploadedEvent]], any[HeaderCarrier])
     }


### PR DESCRIPTION
With the upscan callback being handled async now with mongo work items, it needs to be idempotent. 

This PR is to address that issue and avoid any re-processing of already validated/submitted uploads, and stop the backed from reporting a 409.